### PR TITLE
Adiciona cópia de objetivos por campos de experiência no plano de ensino por área de conhecimento

### DIFF
--- a/app/controllers/knowledge_area_teaching_plans_controller.rb
+++ b/app/controllers/knowledge_area_teaching_plans_controller.rb
@@ -7,6 +7,7 @@ class KnowledgeAreaTeachingPlansController < ApplicationController
   before_action :require_allow_to_modify_prev_years, only: [:create, :update, :destroy]
   before_action :yearly_term_type_id, only: [:show, :edit, :new]
   before_action :require_current_classroom, only: [:index, :new, :create, :edit, :update]
+  before_action :require_allows_copy_experience_fields_in_lesson_plans, only: [:new, :edit]
 
   def index
     params[:filter] ||= {}
@@ -208,6 +209,10 @@ class KnowledgeAreaTeachingPlansController < ApplicationController
   end
 
   private
+
+  def require_allows_copy_experience_fields_in_lesson_plans
+    @allows_copy_experience_fields_in_lesson_plans ||= GeneralConfiguration.current.allows_copy_experience_fields_in_lesson_plans
+  end
 
   def content_ids
     param_content_ids = params[:knowledge_area_teaching_plan][:teaching_plan_attributes][:content_ids] || []

--- a/app/views/knowledge_area_teaching_plans/_form.html.erb
+++ b/app/views/knowledge_area_teaching_plans/_form.html.erb
@@ -21,8 +21,11 @@
     <%= teaching_plan_form.hidden_field :id %>
 
     <fieldset>
-      <% school_type = GeneralConfiguration.current.group_children_education ? 'group_child_schools' : 'experience_fields' %>
-      <%= render 'teaching_plans/copy_objectives', f: teaching_plan_form, type: school_type, modal_id: 'confirm-copy-objectives-modal', confirm_btn: 'confirm-copy-objectives-btn'  %>
+      <%= render 'teaching_plans/diciplines_modal', f: teaching_plan_form %>
+      <% if @allows_copy_experience_fields_in_lesson_plans %>
+        <% school_type = GeneralConfiguration.current.group_children_education ? 'group_child_schools' : 'experience_fields' %>
+        <%= render 'teaching_plans/copy_objectives', f: teaching_plan_form, type: school_type, modal_id: 'confirm-copy-objectives-modal', confirm_btn: 'confirm-copy-objectives-btn' %>
+      <% end %>
 
       <div id='copy_plan_info' class='alert alert-info' style='display: none;'>
         <i class='fa-fw fa fa-info'></i>
@@ -157,9 +160,14 @@
           <% end %>
 
           <% if !action_name.eql?('show') %>
-            <a href="#" data-toggle="modal" data-target="#confirm-copy-objectives-modal">
+            <a href="#" data-toggle="modal" data-target="#disciplines-modal">
               Copiar objetivos/habilidades por área
             </a>
+            <% if @allows_copy_experience_fields_in_lesson_plans %>
+              |<a href="#" data-toggle="modal" data-target="#confirm-copy-objectives-modal">
+                Copiar objetivos por campos de experiência
+              </a>
+            <% end %>
           <% end %>
 
             <div class="well" style="max-height: 300px;overflow-y: auto; margin-top: 10px;">


### PR DESCRIPTION
No formulário de Plano de ensino por Área de Conhecimento, o campo de objetivos oferecia apenas uma opção de cópia. Este PR alinha o comportamento ao do plano de ensino por disciplina, com duas opções distintas:

- **Copiar objetivos/habilidades por área**: componentes curriculares (`disciplines`).
- **Copiar objetivos por campos de experiência**: campos BNCC, exibida quando `allows_copy_experience_fields_in_lesson_plans` está habilitada.

## Mudanças
- `knowledge_area_teaching_plans_controller`: define `@allows_copy_experience_fields_in_lesson_plans` em `new`/`edit` (mesmo guard já usado no plano por disciplina).
- `_form.html.erb`: passa a renderizar os dois modais/links, reaproveitando os partials existentes (`diciplines_modal`, `copy_objectives`) e preservando o tratamento de `group_children_education`.
